### PR TITLE
Speed up mirror setup by not copying tarball that is already present

### DIFF
--- a/roles/offline-repo-mirrors/defaults/main.yml
+++ b/roles/offline-repo-mirrors/defaults/main.yml
@@ -3,6 +3,7 @@ offline_cache_dir: "/tmp/deepops"
 build_tar_file: true
 tar_file_path: "/tmp/deepops-archive.tar"
 extract_path: "/tmp/deepops-extracted"
+tar_file_copy: "no"
 
 # Destination for files on repo mirror machine
 deepops_dest_path: "/opt/deepops"

--- a/roles/offline-repo-mirrors/tasks/build-mirrors.yml
+++ b/roles/offline-repo-mirrors/tasks/build-mirrors.yml
@@ -33,6 +33,7 @@
   unarchive:
     src: "{{ tar_file_path }}"
     dest: "{{ extract_path }}"
+    copy: "{{ tar_file_copy }}"
   tags:
   - extract_archive
 


### PR DESCRIPTION
Following the standard instructions building the mirrors is typically done on a machine that already has the tarball in /tmp.

Since the file was already there, setting the unarchive copy flag to no sped up the setup time by 6-12 minutes in my tests.