### PR TITLE
Increase docker push timeout

### DIFF
--- a/roles/offline-repo-mirrors/defaults/main.yml
+++ b/roles/offline-repo-mirrors/defaults/main.yml
@@ -86,7 +86,7 @@ nvidia_k8s_device_plugin_url: "https://raw.githubusercontent.com/NVIDIA/k8s-devi
 nvidia_docker_wrapper_url: "https://raw.githubusercontent.com/NVIDIA/nvidia-docker/master/nvidia-docker"
 
 # Configure download of docker images
-docker_http_timeout: 120
+docker_http_timeout: 180
 docker_image_list:
 - name: "ceph"
   repo: ""


### PR DESCRIPTION
In my tests the docker push failed several times with the default timeout of 120 seconds. Bumping this to 180 seconds seemed to be long enough. Since this is doing everything on localhost and not over the network I'm guessing that this increased timeout should be relevant to anyone running this playbook.