### PR TITLE
Add new task to download createrepo rpms and corresponding url/flag variables

### DIFF
--- a/roles/offline-repo-mirrors/defaults/main.yml
+++ b/roles/offline-repo-mirrors/defaults/main.yml
@@ -16,6 +16,7 @@ deepops_centos_slurm_url: "https://github.com/DeepOps/slurm/releases/download/do
 
 # Flags for downloading content
 download_yum_repos: yes
+download_createrepo_rpms: yes
 download_docker_images: yes
 download_helm_repos: yes
 download_deepops_repo: yes
@@ -30,6 +31,14 @@ upload_helm_chats: yes
 build_pip_mirror: yes
 build_misc_mirror: yes
 
+# Configure RPM locations for createrepo dependencies
+createrepo_dep_url_list:
+  - name: "createrepo.rpm"
+    url: "https://rpmfind.net/linux/centos/7.6.1810/os/x86_64/Packages/createrepo-0.9.9-28.el7.noarch.rpm"
+  - name: "deltarpm.rpm"
+    url: "https://www.rpmfind.net/linux/centos/7.6.1810/os/x86_64/Packages/deltarpm-3.6-3.el7.x86_64.rpm"
+  - name: "python-deltarpm.rpm"
+    url: "https://rpmfind.net/linux/centos/7.6.1810/os/x86_64/Packages/python-deltarpm-3.6-3.el7.x86_64.rpm"
 
 # Configure download of yum repos
 centos_iso_mirror: "http://mirrors.ocf.berkeley.edu/centos/7.6.1810/isos/x86_64"

--- a/roles/offline-repo-mirrors/tasks/build-cache.yml
+++ b/roles/offline-repo-mirrors/tasks/build-cache.yml
@@ -57,6 +57,13 @@
     url: "{{ nvidia_docker_wrapper_url }}"
     dest: "{{ offline_cache_dir }}/misc-files/nvidia-docker"
 
+- name: download createrepo rpm files
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ offline_cache_dir }}/misc-files/{{ item.name }}"
+  with_items: "{{ createrepo_dep_url_list }}"
+  when: download_createrepo_rpms
+
 - name: archive docker images
   docker_image:
     name: "{{ item.repo }}{{ item.image }}"


### PR DESCRIPTION
When building the mirrors I ran into the issue that createrepo was not installed. I had to manually scp over the createrepo, python-deltarpm, and deltarpm rpm files. This could cause an issue if the engineer running these commands went through the process of getting evertyhing through the DMZ only to find out the packages were missing. Ansible will just hange for ~20 minutes at the first part of the playbook before giving a non-obvious yum error message.

I added a few flags with the URLs to where I downloaded these packages from and another flag to enable/disable the download.

In addition to downloading these files we should probably either document that these are included in the tarball (if needed) or add an additional task to install them. I didn't want to add that task just yet as it may be a bit invasive (and error prone).

Let me know if you think there is a better way to include these packages.