### PR TITLE
Add a check for python36, docker, wget, git, etc. to cache builder

### DIFF
--- a/scripts/build_offline_cache.sh
+++ b/scripts/build_offline_cache.sh
@@ -26,8 +26,8 @@ if ! which python36; then
     exit 1
 fi
 
-if ! which docker; then
-    echo "docker needed for Kubespray, please install"
+if ! docker ps; then
+    echo "docker must be installed and running for Kubespray, please install/verify"
     exit 1
 fi
 

--- a/scripts/build_offline_cache.sh
+++ b/scripts/build_offline_cache.sh
@@ -21,6 +21,21 @@ if ! which ruby; then
     exit 1
 fi
 
+if ! which python36; then
+    echo "python36 needed for Kubespray, please install"
+    exit 1
+fi
+
+if ! which docker; then
+    echo "docker needed for Kubespray, please install"
+    exit 1
+fi
+
+if ! ls config; then
+    echo "It looks like you have not run scripts/setup.sh, please see the README and run setup."
+    exit 1
+fi
+
 get_all_helm_tgzs() {
     local repo_url="$1"
     rm -f index.yaml


### PR DESCRIPTION
I just ran through this on a vanilla install of CentOS 7.

In order to download the files I needed to first `sudo yum install -y python36 git wget docker`. I then needed to ensure docker was up and running. If you don't take these steps first it the process will fail, but the error message is fairly obvious and restarting the download picks up from where it left off.

Rather than letting users figure this out on their own, this PR will make sure that python36 is installed (specifically needed by the k8s inventory script) and that the setup.sh script was executed (by verifying it copied config.example to config). setup.sh installs wget, git.

Rather than duplicate code in setup.sh, I think we should just have users run it. It might do some unnecessary tasks, but most of them are fast and harmless.

The only issue I could see with this is checking that docker is up using "docker images" as a test. On my system I needed the user I was running the script on (centos) to have docker access, and that command will fail if that is not the case. This could have some unexpected edge cases though.