### PR TITLE
missing jinja2 pip package

### DIFF
--- a/roles/offline-repo-mirrors/defaults/main.yml
+++ b/roles/offline-repo-mirrors/defaults/main.yml
@@ -332,6 +332,7 @@ pip_package_list:
 - name: "openshift"
 - name: "pip"
 - name: "setuptools"
+- name: "Jinja2"
 
 pip_port: 8003
 pip_src_path: "{{ extract_path }}/pip"


### PR DESCRIPTION
We need to run setup.sh on the mgmt node. Currently this is unable to upgrade jinja2, this causes the the Kubespray install to fail.

