### PR TITLE
Bump GPU Operator to 1.70

### DIFF
--- a/config.example/group_vars/k8s-cluster.yml
+++ b/config.example/group_vars/k8s-cluster.yml
@@ -20,6 +20,14 @@ kubelet_flexvolumes_plugins_dir: /usr/libexec/kubernetes/kubelet-plugins/volume/
 # Docker configuration.
 deepops_gpu_operator_enabled: false
 
+# Enable / disable specific components of the GPU Operator
+# Setting driver and toolkit to false will allow the Operator to run with pre-existing drivers
+k8s_driver_enabled: "true"
+k8s_toolkit_enabled: "true"
+
+# Deploy the MIG manager with the GPU Operator
+k8s_mig_manager_enabled: "true"
+
 # Set the MIG labeling and use strategy to none, single, or mixed. See https://github.com/NVIDIA/k8s-device-plugin
 k8s_gpu_mig_strategy: "mixed"
 

--- a/roles/nvidia-gpu-operator/defaults/main.yml
+++ b/roles/nvidia-gpu-operator/defaults/main.yml
@@ -5,11 +5,18 @@
 # See https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/getting-started.html#considerations-to-install-gpu-operator-with-nvidia-vgpu-driver
 #  for additional details around buidling/pushing/using driver containers and setting gpu_operator_driver_version to the correct value
 
+
+# Enable/Disable specific optional components
+# XXX: When instlalling on a node with pre-existing drivers, set driver/toolkit to false
+k8s_driver_enabled: "true"
+k8s_toolkit_enabled: "true"
+k8s_mig_manager_enabled: "true"
+
 # Vars needed to install operator
 gpu_operator_helm_repo: "https://nvidia.github.io/gpu-operator"
 gpu_operator_chart_name: "nvidia/gpu-operator"
 gpu_operator_release_name: "nvidia-gpu-operator"
-gpu_operator_chart_version: "1.6.2"
+gpu_operator_chart_version: "1.7.0"
 k8s_gpu_mig_strategy: "mixed"
 
 # Configuration customization
@@ -20,15 +27,9 @@ gpu_operator_grid_config_dir: "{{ deepops_dir }}/gpu_operator"
 # Defaults from https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml
 gpu_operator_default_runtime: "docker"
 gpu_operator_driver_registry: "nvcr.io/nvidia"
-gpu_operator_driver_version: "460.32.03"
+gpu_operator_driver_version: "460.73.01"
 deepops_dir: "/opt/deepops"
 gpu_operator_config_dir: "{{ deepops_dir }}/gpu-operator"
-gpu_operator_plugin_args:
-- "--mig-strategy={{ k8s_gpu_mig_strategy }}"
-- "--pass-device-specs=true"
-- "--fail-on-init-error=true"
-- "--device-list-strategy=envvar"
-- "--nvidia-driver-root=/run/nvidia/driver"
 gpu_operator_dcgm_version: "2.1.8-2.4.0-rc.2-ubuntu20.04"
 gpu_operator_dcgm_config_csv: "dcgm-custom-metrics.csv"
 gpu_operator_values_file: "gpu-operator-values.yml"

--- a/roles/nvidia-gpu-operator/templates/gpu-operator-values.yml
+++ b/roles/nvidia-gpu-operator/templates/gpu-operator-values.yml
@@ -1,13 +1,16 @@
-migStrategy: "{{ k8s_gpu_mig_strategy }}"
+# For full options & documentation see: https://github.com/NVIDIA/gpu-operator/blob/master/deployments/gpu-operator/values.yaml
+validator:
 operator:
   defaultRuntime: "{{ gpu_operator_default_runtime }}"
+mig:
+  strategy: "{{ k8s_gpu_mig_strategy }}"
 driver:
+  enabled: "{{ k8s_driver_enabled }}"
   repository: "{{ gpu_operator_driver_registry }}"
   version: "{{ gpu_operator_driver_version }}"
-gfd:
-  migStrategy: "{{ k8s_gpu_mig_strategy }}"
+toolkit:
+  enabled: "{{ k8s_toolkit_enabled }}"
 devicePlugin:
-  args: {{ gpu_operator_plugin_args }}
 dcgmExporter:
   version: "{{ gpu_operator_dcgm_version }}"
   extraHostVolumes:
@@ -18,3 +21,6 @@ dcgmExporter:
       mountPath: "/etc/dcgm-config"
       readOnly: true
   args: ["-f", "/etc/dcgm-config/dcgm-custom-metrics.csv"]
+gfd:
+migManager:
+  enabled: "{{ k8s_mig_manager_enabled }}"


### PR DESCRIPTION
* Bump GPU Operator from 1.6.2 to 1.7.0
* Bump default driver version along with it according to the default values.yaml
* Move mig.strategy from being an embedded --args=migStrategy={{var}} object to a proper mig.strategy entry in values.yaml, now that the helm chart supports this
* Add toolkit.enabled, driver.enabled, and migmanager.enabled default config values to add support for GPU Operator on nodes with pre-installed drivers
* Move the values in the template around so that they match the helm chart's values.yaml